### PR TITLE
corrections to runtime depends and add ability to display Repology tracked packaging of Quickword

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Select a word and hit the a keyboard shortcut to get the lookup. Recommended sho
 ![](data/demo.gif)
 
 # Installation
+QuickWord is availble for installation in the following Linux Distribution repositories
+<a href="https://repology.org/project/quickword/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/quickword.svg" alt="Packaging status" align="right">
+</a>
+
 
 ## Build using flatpak
 * requires that you have flatpak-builder installed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Select a word and hit the a keyboard shortcut to get the lookup. Recommended sho
 ![](data/demo.gif)
 
 # Installation
-QuickWord is availble for installation in the following Linux Distribution repositories
+QuickWord is availble for installation in the following Linux Distributions
 <a href="https://repology.org/project/quickword/versions">
     <img src="https://repology.org/badge/vertical-allrepos/quickword.svg" alt="Packaging status" align="right">
 </a>

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,7 @@ Depends: ${python3:Depends},
          ${misc:Depends},
          python3,
          python3-gi,
-         libgranite-dev,
+         python3-xlib
          python3-nltk,
          espeak,
          gir1.2-granite-1.0,
@@ -26,9 +26,9 @@ Description: Quick and easy word lookup on the fly and offline
  on the fly.
  .
  Features:
-• On the fly word lookup
-• Works offline (first run will require internet to download dictionary data)
-• Copy definitions and examples to clipboard with just a click
-• Word definitions
-• Examples of word sentences
-• Explore synonyms from each word
+ • On the fly word lookup
+ • Works offline (first run will require internet to download dictionary data)
+ • Copy definitions and examples to clipboard with just a click
+ • Word definitions
+ • Examples of word sentences
+ • Explore synonyms from each word


### PR DESCRIPTION
I verified the build and runtime depends, Quickword builds and works using these, and it reduces the need to have all the -dev packages from being added at install time